### PR TITLE
Fix build info metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	metrics := prometheus.NewRegistry()
 	metrics.MustRegister(
-		version.NewCollector("thanos-replicate"),
+		version.NewCollector("thanos_replicate"),
 		prometheus.NewGoCollector(),
 		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
 	)


### PR DESCRIPTION
This string is used to build the build info metric, and dashes are illegal characters in Prometheus metric names.