### PR TITLE
scheme.go: Fix writing meta.json

### DIFF
--- a/scheme.go
+++ b/scheme.go
@@ -221,14 +221,13 @@ func (rs *replicationScheme) ensureBlockIsReplicated(ctx context.Context, id uli
 		return fmt.Errorf("get meta file from target bucket: %w", err)
 	}
 
-	var originMetaFileContent, targetMetaFileContent []byte
-	if targetMetaFile != nil && !rs.toBkt.IsObjNotFoundErr(err) {
-		originMetaFileContent, err = ioutil.ReadAll(originMetaFile)
-		if err != nil {
-			return fmt.Errorf("read origin meta file: %w", err)
-		}
+	originMetaFileContent, err := ioutil.ReadAll(originMetaFile)
+	if err != nil {
+		return fmt.Errorf("read origin meta file: %w", err)
+	}
 
-		targetMetaFileContent, err = ioutil.ReadAll(targetMetaFile)
+	if targetMetaFile != nil && !rs.toBkt.IsObjNotFoundErr(err) {
+		targetMetaFileContent, err := ioutil.ReadAll(targetMetaFile)
 		if err != nil {
 			return fmt.Errorf("read target meta file: %w", err)
 		}

--- a/scheme_test.go
+++ b/scheme_test.go
@@ -283,6 +283,10 @@ func TestReplicationSchemeAll(t *testing.T) {
 				if len(targetBucket.Objects()) != 3 {
 					t.Fatal("TargetBucket should have one block does not.")
 				}
+
+				expected := originBucket.Objects()["01DQYXMK8G108CEBQ79Y84DYVY/meta.json"]
+				got := targetBucket.Objects()["01DQYXMK8G108CEBQ79Y84DYVY/meta.json"]
+				testutil.Equals(t, expected, got)
 			},
 		},
 	}


### PR DESCRIPTION
Previously the meta.json was never read if the object was not present in
the target bucket, therefore the initial sync always failed.

@metalmatze @squat @bwplotka @kakkoyun 